### PR TITLE
[Fix] Compatibility with Telegram's official documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,7 @@ pub fn parse(init_data: &str) -> Result<InitData, ParseDataError> {
     // Create a static HashSet of properties that should always be interpreted as strings
     static STRING_PROPS: phf::Set<&'static str> = phf::phf_set! {
         "start_param",
+        "chat_instance",
     };
 
     // Build JSON pairs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub struct InitData {
 
     /// The unique session ID of the Mini App.
     /// Used in the process of sending a message via the method answerWebAppQuery.
-    pub query_id: String,
+    pub query_id: Option<String>,
 
     /// An object containing data about the chat partner of the current user in the chat where the bot was launched via the attachment menu.
     /// Returned only for private chats and only for Mini Apps launched via the attachment menu.
@@ -343,7 +343,7 @@ mod tests {
                 chat_instance: None,
                 hash: "c501b71e775f74ce10e377dea85a7ea24ecd640b223ea86dfe453e0eaed2e2b2"
                     .to_string(),
-                query_id: "AAHdF6IQAAAAAN0XohDhrOrc".to_string(),
+                query_id: Some("AAHdF6IQAAAAAN0XohDhrOrc".to_string()),
                 receiver: None,
                 start_param: Some("abc".to_string()),
                 user: Some(User {


### PR DESCRIPTION
This pull request addresses a few issues to align the library's behavior with Telegram's official documentation:

1. `query_id` property in `InitData` should be optional.
&nbsp;
Updated the type definition and handling logic for query_id to make it optional, as per the official specification.
&nbsp;
2. `chat_instance` property should always be treated as a string.
&nbsp;
Resolved a type handling issue where chat_instance was incorrectly interpreted as an integer in some cases.
&nbsp;
In my case this resulted in the following error:
`InvalidSignature(Error("invalid type: integer -1234567890123456789, expected a string", line: 1, column: 293)).`